### PR TITLE
-A temporal workaround for the problem when hTab->GetRecords()->GetCo…

### DIFF
--- a/src/OSPSuite.SimModelComp/src/SimModelComp.cpp
+++ b/src/OSPSuite.SimModelComp/src/SimModelComp.cpp
@@ -684,13 +684,17 @@ void SimModelComp::UpdateOutputTimeSchema()
 		double endTime         = hTab->GetValue(intervalIdx, conEndTime);
 		int numberOfTimePoints = hTab->GetValue(intervalIdx, conNoOfTimePoints);
 
-		OutputIntervalDistribution pointsDistribution = IntervalDistributionFromString(
-			                     hTab->GetValue(intervalIdx, conDistribution));
+      //Just a temporal workaround for the problem when hTab->GetRecords()->GetCount();
+      //returns more intervals than present.
+      if (numberOfTimePoints > 0) {
+         OutputIntervalDistribution pointsDistribution = IntervalDistributionFromString(
+            hTab->GetValue(intervalIdx, conDistribution));
 
-		OutputInterval * interval = new OutputInterval
-			(startTime, endTime, numberOfTimePoints, pointsDistribution);
+         OutputInterval * interval = new OutputInterval
+         (startTime, endTime, numberOfTimePoints, pointsDistribution);
 
-		outSchema.OutputIntervals().push_back(interval);
+         outSchema.OutputIntervals().push_back(interval);
+      }
 	}
 }
 


### PR DESCRIPTION
…unt(); returns more intervals than present. If the number of points is 0 (indicating a non-existent entry), the entry is ignored.